### PR TITLE
feat: Add JSDoc comments to Home.vue

### DIFF
--- a/src/components/Main/General/Home.vue
+++ b/src/components/Main/General/Home.vue
@@ -67,7 +67,18 @@
 
 
 <script>
+/**
+ * @file Home.vue
+ * @description This component serves as the main landing page for On The Go Rentals.
+ * It displays a welcome message, highlights key service categories (Economy, Luxury, Special Offers),
+ * and provides navigation links to view car listings for these categories.
+ * @component Home
+ */
 export default {
+  /**
+   * The registered name of the component.
+   * @type {string}
+   */
   name: 'Home',
 };
 </script>


### PR DESCRIPTION
Added JSDoc-style comments to the <script> section of the `src/components/Main/General/Home.vue` component.

This includes a component-level comment explaining its purpose and JSDoc tags for the component's name property. The template was reviewed and deemed self-explanatory, so no comments were added there.